### PR TITLE
Fix animation in handlePanResponderEnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var MyComponent = React.createClass({
     return (
       <ScrollView style={{flex: 1,}}>
         <SwipeableElement
-          compnent={<Text>{'Some Text'}</Text>}
+          component={<Text>{'Some Text'}</Text>}
           swipeRightTitle={'Delete'}
           swipeRightTextColor={'#FFFFFF'}
           swipeRightBackgroundColor={'#000000'}

--- a/SwipeableElement.js
+++ b/SwipeableElement.js
@@ -113,8 +113,7 @@ var SwipeableElement = React.createClass({
         this.props.onSwipeLeft.call();
       }
     }
-    var animations = require('../../TaskList/animations');
-    LayoutAnimation.configureNext(animations.easeInEaseOut);
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     this.setState({dx:0,});
     this.refs.mainElement && this.refs.mainElement.setNativeProps({ left: 0 });
     this.refs.leftElement && this.refs.leftElement.setNativeProps({ width: 0, left: 0, });


### PR DESCRIPTION
Releasing a drag crashed the app, caused by including a instance-specific or old module `require('../../TaskList/animations');`

As of react-native v0.4.4, it's accessible on `LayoutAnimation.Presets.easeInEaseOut`
